### PR TITLE
Don't index English words

### DIFF
--- a/instant-distance-py/examples/translations/translate.py
+++ b/instant-distance-py/examples/translations/translate.py
@@ -68,6 +68,11 @@ async def download_build_index():
                         if lang == "en":
                             word_map[value] = embedding
                         else:
+                            # Don't index words that exist in english
+                            # to improve the quality of the results.
+                            if value in word_map:
+                                continue
+
                             # We track values here to build the instant-distance index
                             # Every value is prepended with 2 character language code.
                             # This allows us to determine language output later.


### PR DESCRIPTION
This PR omits English words from the HNSW index for fr and it. The results look a little more accurate:

```
> python3.9 translate.py translate apple

Loading indexes from filesystem...
Language: fr, Translation: pastèque
Language: fr, Translation: abricot
Language: it, Translation: nutella
Language: fr, Translation: cerise
Language: it, Translation: ciliegia
Language: it, Translation: palmari
Language: it, Translation: cocco
Language: it, Translation: fragola
Language: fr, Translation: noisettes
Language: fr, Translation: ananas

```

```
> python3.9 translate.py translate hello

Loading indexes from filesystem...
Language: fr, Translation: bonjours
Language: fr, Translation: bonsoir
Language: fr, Translation: salutations
Language: it, Translation: buongiorno
Language: it, Translation: buonanotte
Language: fr, Translation: rebonjour
Language: it, Translation: auguri
Language: fr, Translation: bonjour,
Language: it, Translation: buonasera
Language: it, Translation: chiamatemi
```

```
> python3.9 translate.py translate dog

Loading indexes from filesystem...
Language: it, Translation: cani
Language: fr, Translation: chiens
Language: fr, Translation: chienne
Language: it, Translation: cucciolo
Language: fr, Translation: chiot
Language: it, Translation: coniglio
Language: fr, Translation: cochon
Language: it, Translation: maialino
Language: it, Translation: cagnolino
Language: fr, Translation: canin
```