### PR TITLE
Prepare another Python bindings release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python: [3.7, 3.8, 3.9]
+        python: [3.8, 3.9, 3.10, 3.11]
 
     runs-on: ${{ matrix.os }}
     environment: "Publish wheels"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           command: publish
           args: -m instant-distance-py/Cargo.toml
-                --no-sdist
                 --username __token__
                 --password ${{ secrets.PYPI_TOKEN }}
                 --interpreter python${{ matrix.python }}
@@ -52,6 +51,5 @@ jobs:
         with:
           command: publish
           args: -m instant-distance-py/Cargo.toml
-                --no-sdist
                 --username __token__
                 --password ${{ secrets.PYPI_TOKEN }}

--- a/instant-distance-py/Cargo.toml
+++ b/instant-distance-py/Cargo.toml
@@ -20,6 +20,3 @@ instant-distance = { version = "0.6", path = "../instant-distance", features = [
 pyo3 = { version = "0.18.0", features = ["extension-module"] }
 serde = { version = "1", features = ["derive"] }
 serde-big-array = "0.4.1"
-
-[package.metadata.maturin]
-name = "instant-distance"

--- a/instant-distance-py/Cargo.toml
+++ b/instant-distance-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instant-distance-py"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 rust-version = "1.58"
 license = "MIT OR Apache-2.0"

--- a/instant-distance-py/examples/translations/requirements.txt
+++ b/instant-distance-py/examples/translations/requirements.txt
@@ -1,3 +1,3 @@
-aiohttp==3.8.1
+aiohttp==3.8.3
 progress==1.6
 instant-distance==0.3.1

--- a/instant-distance-py/examples/translations/translate.py
+++ b/instant-distance-py/examples/translations/translate.py
@@ -149,5 +149,5 @@ async def main():
     exit(1)
 
 
-loop = asyncio.get_event_loop()
-loop.run_until_complete(main())
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/instant-distance-py/pyproject.toml
+++ b/instant-distance-py/pyproject.toml
@@ -1,3 +1,6 @@
+[project]
+name = "instant-distance"
+
 [build-system]
-requires = ["maturin >= 0.11, < 0.12"]
+requires = ["maturin >= 0.14, < 0.15"]
 build-backend = "maturin"


### PR DESCRIPTION
Since the Windows release failed and lacked Python > 3.9, prepare another release. See [feedback](https://github.com/axodotdev/cargo-dist/issues/86#issuecomment-1413371321) from the maturin maintainer.